### PR TITLE
DATABASE Add user column to jobs table

### DIFF
--- a/ccf/app/models.py
+++ b/ccf/app/models.py
@@ -1,4 +1,5 @@
 import django
+from django.contrib.auth.models import User
 from django.db import models
 from django.db.utils import IntegrityError
 
@@ -7,6 +8,7 @@ class Job(models.Model):
     finished = models.BooleanField(default=False)
     time_started = models.DateTimeField(default=django.utils.timezone.now, blank=False)
     dockerfile = models.TextField()
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
 
     # Arbitrary max length for prototype.
     datastore_link = models.CharField(max_length=50)
@@ -18,5 +20,8 @@ class Job(models.Model):
 
         if not self.datastore_link:
             raise IntegrityError("datastore_link value must not be blank.")
+
+        if not self.user_id:
+            raise IntegrityError("user_id could not be found.")
 
         super(Job, self).save(*args, **kwargs)

--- a/ccf/tests/test_models.py
+++ b/ccf/tests/test_models.py
@@ -43,7 +43,7 @@ def test_create_job_without_finished_auto_fills_field_to_false():
 
 
 @pytest.mark.django_db()
-def test_create_job_without_finished_auto_fills_field_to_false():
+def test_create_job_without_user_raises_integrity_error():
     job = Job(
         finished=False, dockerfile="this is a dockerfile.", datastore_link="abc.com"
     )

--- a/ccf/tests/test_models.py
+++ b/ccf/tests/test_models.py
@@ -6,7 +6,10 @@ from app.models import Job
 @pytest.mark.django_db()
 def test_create_job_entry():
     job = Job(
-        finished=False, dockerfile="this is a dockerfile.", datastore_link="abc.com"
+        finished=False,
+        dockerfile="this is a dockerfile.",
+        datastore_link="abc.com",
+        user_id="123",
     )
 
     job.save()
@@ -16,7 +19,7 @@ def test_create_job_entry():
 
 @pytest.mark.django_db()
 def test_creating_job_without_dockerfile_raises_integrity_error():
-    job = Job(finished=False, datastore_link="abc.com")
+    job = Job(finished=False, datastore_link="abc.com", user_id="123")
 
     with pytest.raises(django.db.utils.IntegrityError):
         job.save()
@@ -24,7 +27,7 @@ def test_creating_job_without_dockerfile_raises_integrity_error():
 
 @pytest.mark.django_db()
 def test_create_job_without_datastore_link_raises_integrity_error():
-    job = Job(finished=False, dockerfile="this is a dockerfile.")
+    job = Job(finished=False, dockerfile="this is a dockerfile.", user_id="123")
 
     with pytest.raises(django.db.utils.IntegrityError):
         job.save()
@@ -32,6 +35,18 @@ def test_create_job_without_datastore_link_raises_integrity_error():
 
 @pytest.mark.django_db()
 def test_create_job_without_finished_auto_fills_field_to_false():
-    job = Job(dockerfile="This is a dockerfile", datastore_link="abc.com")
+    job = Job(
+        dockerfile="This is a dockerfile", datastore_link="abc.com", user_id="123"
+    )
 
     assert not job.finished
+
+
+@pytest.mark.django_db()
+def test_create_job_without_finished_auto_fills_field_to_false():
+    job = Job(
+        finished=False, dockerfile="this is a dockerfile.", datastore_link="abc.com"
+    )
+
+    with pytest.raises(django.db.utils.IntegrityError):
+        job.save()


### PR DESCRIPTION
In order to set up creating and managing jobs, a user column is required. This PR adds that column.